### PR TITLE
fix some bugs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,8 @@ Pillow
 PyYAML>=5.3.1
 scipy>=1.4.1
 tensorboard>=1.5
-torch==1.7.0
-torchvision==0.8.1
+torch>=1.7.0
+torchvision>=0.8.1
 tqdm>=4.41.0
 
 # logging -------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,4 +27,4 @@ pandas
 
 # extras --------------------------------------
 thop  # FLOPS computation
-pycocotools==2.0  # COCO mAP
+pycocotools==2.0.2  # COCO mAP

--- a/utils/plots.py
+++ b/utils/plots.py
@@ -90,11 +90,11 @@ def output_to_target(output, width, height):
     # Convert model output to target format [batch_id, class_id, x, y, w, h, conf]
     if isinstance(output, torch.Tensor):
         output = output.cpu().numpy()
-
     targets = []
     for i, o in enumerate(output):
         if o is not None:
             for pred in o:
+                pred = pred.cpu()
                 box = pred[:4]
                 w = (box[2] - box[0]) / width
                 h = (box[3] - box[1]) / height
@@ -104,7 +104,6 @@ def output_to_target(output, width, height):
                 cls = int(pred[5])
 
                 targets.append([i, cls, x, y, w, h, conf])
-
     return np.array(targets)
 
 


### PR DESCRIPTION
close #43 


Hi.
I had some problems running `test.py` and I fixed them.

+ [ ] Error in `pip install -r requirements.txt`

```bash
ERROR: Could not find a version that satisfies the requirement torch==1.7.0 (from versions: 0.1.2, 0.1.2.post1, 0.1.2.post2, 1.7.1, 1.8.0, 1.8.1, 1.9.0)
ERROR: No matching distribution found for torch==1.7.0
```

+ [ ]Error in `python test.py --data data/coco.yaml --img 1280 --batch 32 --conf 0.001 --iou 0.65 --device 0 --cfg cfg/yolor_p6.cfg --weights yolor_p6.pt --name yolor_p6_val`

```bash
Traceback (most recent call last):
  File "/home/satoharu/yolor/test.py", line 319, in <module>
    test(opt.data,
  File "/home/satoharu/yolor/test.py", line 226, in test
    plot_images(img, output_to_target(output, width, height), paths, f, names)  # predictions
  File "/home/satoharu/yolor/utils/plots.py", line 106, in output_to_target
    return np.array(targets)
  File "/home/satoharu/.pyenv/versions/3.9.6_yolor/lib/python3.9/site-packages/torch/_tensor.py", line 643, in __array__
    return self.numpy()
TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
```
and

```bash
ERROR: pycocotools unable to run: 'numpy.float64' object cannot be interpreted as an integer
Results saved to runs/test/yolor_p6_val11
```

I updated your `requirements.txt` and `utils/plots.py`. Would you please check them and merge this pull request?

Thanks.
