### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ Pillow
 PyYAML>=5.3.1
 scipy>=1.4.1
 tensorboard>=1.5
-torch==1.7.0
+torch==1.10.0
 torchvision==0.8.1
 tqdm>=4.41.0
 


### PR DESCRIPTION
Running on Colab shows

ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
torchtext 0.11.0 requires torch==1.10.0, but you have torch 1.7.0 which is incompatible.
torchaudio 0.10.0+cu111 requires torch==1.10.0, but you have torch 1.7.0 which is incompatible.