### PR TITLE
fixed function return type error 'output_to_target'

### DIFF
--- a/utils/plots.py
+++ b/utils/plots.py
@@ -105,7 +105,7 @@ def output_to_target(output, width, height):
 
                 targets.append([i, cls, x, y, w, h, conf])
 
-    return np.array(targets)
+    return torch.tensor(targets)
 
 
 def plot_images(images, targets, paths=None, fname='images.jpg', names=None, max_size=640, max_subplots=16):


### PR DESCRIPTION
fixed an error when testing and training the model on a custom dataset.
"
Traceback (most recent call last):
  File "test.py", line 319, in <module>
    test(opt.data,
  File "test.py", line 226, in test
    plot_images(img, output_to_target(output, width, height), paths, f, names)  # predictions
  File "/yolor/utils/plots.py", line 109, in output_to_target
    return np.array(targets)
  File "/opt/conda/lib/python3.8/site-packages/torch/_tensor.py", line 721, in __array__
    return self.numpy()
TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
"